### PR TITLE
Optimize MySQL configuration for large servers (64GB+)

### DIFF
--- a/assets/js/calculations.js
+++ b/assets/js/calculations.js
@@ -111,19 +111,23 @@ export class MySQLCalculator {
    * Calculate optimal buffer pool percentage based on server characteristics
    */
   calculateOptimalBufferPoolPercentage(totalMemory, availableMemory, isDedicated, templateSettings) {
-    // Base percentage from research: 70-80% for dedicated servers
+    // Base percentage from research: 70-88% for dedicated servers, 75-88% for 64GB+
     let bufferPoolPercentage = CONSTANTS.BUFFER_POOL_PERCENTAGE; // 0.7
 
     if (isDedicated) {
       // For dedicated database servers, use higher percentages as recommended
-      if (totalMemory >= 64) {
-        // Very large dedicated servers: 75% (upper end of recommendation)
-        bufferPoolPercentage = 0.75;
+      // Research shows 75-88% is optimal for large servers (64GB+)
+      if (totalMemory >= 128) {
+        // Very large dedicated servers (128GB+): 85% - aggressive allocation
+        bufferPoolPercentage = 0.85;
+      } else if (totalMemory >= 64) {
+        // Large dedicated servers (64-128GB): 80% - research-backed optimal
+        bufferPoolPercentage = 0.80;
       } else if (totalMemory >= 32) {
-        // Large dedicated servers: 75%
+        // Medium-large dedicated servers: 75%
         bufferPoolPercentage = 0.75;
       } else if (totalMemory >= 16) {
-        // Medium dedicated servers: 70-75%
+        // Medium dedicated servers: 72%
         bufferPoolPercentage = 0.72;
       } else if (totalMemory >= 8) {
         // Small dedicated servers: 70%
@@ -131,7 +135,9 @@ export class MySQLCalculator {
       }
     } else {
       // For shared servers, be more conservative
-      if (totalMemory > 32) {
+      if (totalMemory > 64) {
+        bufferPoolPercentage = 0.65; // Conservative for very large shared servers
+      } else if (totalMemory > 32) {
         bufferPoolPercentage = 0.60; // Conservative for large shared servers
       } else if (totalMemory > 16) {
         bufferPoolPercentage = 0.65; // Moderate for medium shared servers
@@ -179,8 +185,10 @@ export class MySQLCalculator {
     );
 
     // Smart connections per GB based on server characteristics
+    // Research shows: connection pools typically need 100-500 connections max
+    // 1500+ is "uncommonly high"; each connection uses ~196KB + per-query buffers
     let connectionsPerGB = CONSTANTS.CONNECTIONS_PER_GB;
-    
+
     if (isDedicated) {
       // Dedicated servers can handle more connections per GB
       if (totalMemory < 4) {
@@ -201,6 +209,23 @@ export class MySQLCalculator {
       }
     }
 
+    // Calculate base connections, then apply realistic caps
+    let maxConnections = Math.floor(availableMemory * connectionsPerGB);
+
+    // Apply realistic connection caps based on server size
+    // Research: typical workloads need 100-500 connections, rarely more than 1500
+    if (totalMemory >= 128) {
+      maxConnections = Math.min(maxConnections, 2000); // Cap at 2000 for very large servers
+    } else if (totalMemory >= 64) {
+      maxConnections = Math.min(maxConnections, 1500); // Cap at 1500 for large servers
+    } else if (totalMemory >= 32) {
+      maxConnections = Math.min(maxConnections, 1000); // Cap at 1000 for medium servers
+    } else if (totalMemory >= 16) {
+      maxConnections = Math.min(maxConnections, 500); // Cap at 500 for smaller servers
+    } else {
+      maxConnections = Math.min(maxConnections, 300); // Cap at 300 for small servers
+    }
+
     const calculations = {
       // Core InnoDB settings with improved buffer pool calculation
       innodb_buffer_pool_size: Math.floor(availableMemoryBytes * bufferPoolPercentage),
@@ -213,8 +238,8 @@ export class MySQLCalculator {
       innodb_thread_concurrency: CONSTANTS.THREAD_CONCURRENCY,
       innodb_flush_neighbors: storageOpts.flushNeighbors,
 
-      // Connection settings adjusted for dedicated vs shared
-      max_connections: Math.floor(availableMemory * connectionsPerGB),
+      // Connection settings adjusted for dedicated vs shared, with realistic caps
+      max_connections: maxConnections,
 
       // MyISAM settings
       key_buffer_size: Math.floor(availableMemoryBytes * CONSTANTS.KEY_BUFFER_PERCENTAGE),
@@ -250,14 +275,36 @@ export class MySQLCalculator {
     // Calculate log file size based on buffer pool (25% is optimal for most workloads)
     calculations.innodb_log_file_size = Math.floor(calculations.innodb_buffer_pool_size * CONSTANTS.LOG_FILE_RATIO);
 
-    // Adjust IO capacity based on server characteristics and workload
-    if (isDedicated && totalMemory > 16) {
-      // Dedicated servers with substantial memory can handle higher IO capacity
-      calculations.innodb_io_capacity = Math.floor(calculations.innodb_io_capacity * 1.3);
-    } else if (totalMemory > 32) {
-      // Large servers get moderate boost
-      calculations.innodb_io_capacity = Math.floor(calculations.innodb_io_capacity * 1.2);
+    // Adjust IO capacity based on server characteristics, storage type, and workload
+    // Modern NVMe drives can handle much higher IOPS than the base calculation suggests
+    const storageType = inputs.storageType || 'ssd';
+
+    if (storageType === 'nvme') {
+      // NVMe systems benefit from more aggressive I/O settings
+      if (totalMemory >= 128) {
+        // Very large NVMe systems: 2.5x boost
+        calculations.innodb_io_capacity = Math.floor(calculations.innodb_io_capacity * 2.5);
+      } else if (totalMemory >= 64) {
+        // Large NVMe systems: 2.0x boost
+        calculations.innodb_io_capacity = Math.floor(calculations.innodb_io_capacity * 2.0);
+      } else if (totalMemory >= 32) {
+        // Medium NVMe systems: 1.5x boost
+        calculations.innodb_io_capacity = Math.floor(calculations.innodb_io_capacity * 1.5);
+      } else if (isDedicated && totalMemory > 16) {
+        // Smaller dedicated NVMe: 1.3x boost
+        calculations.innodb_io_capacity = Math.floor(calculations.innodb_io_capacity * 1.3);
+      }
+    } else if (storageType === 'ssd') {
+      // SSD systems get moderate boosts
+      if (isDedicated && totalMemory > 16) {
+        // Dedicated SSD servers with substantial memory
+        calculations.innodb_io_capacity = Math.floor(calculations.innodb_io_capacity * 1.3);
+      } else if (totalMemory > 32) {
+        // Large SSD servers get moderate boost
+        calculations.innodb_io_capacity = Math.floor(calculations.innodb_io_capacity * 1.2);
+      }
     }
+    // HDD systems keep conservative settings (no additional boost)
 
     // Adjust temporary table sizes for analytical workloads
     if (templateSettings?.name?.toLowerCase() === 'olap') {
@@ -488,10 +535,32 @@ export class MySQLCalculator {
     const recommendations = [];
     const { availableMemory, totalMemory } = inputs;
 
+    // Warning for unrealistic connection counts
+    if (calculations.max_connections > 1500) {
+      recommendations.push("WARNING: Connection counts above 1500 are uncommonly high. Each connection uses ~196KB + per-query buffers. Consider using connection pooling at the application level to reduce server-side connections.");
+    } else if (calculations.max_connections > 1000) {
+      recommendations.push("NOTE: Your connection count is high. Verify this aligns with your actual concurrent user requirements. Connection pooling is recommended for most applications.");
+    }
+
+    // Warning about buffer pool instances ratio
+    const bufferPoolGB = convertBytesToGB(calculations.innodb_buffer_pool_size);
+    const expectedInstances = bufferPoolGB >= 64 ? bufferPoolGB : Math.ceil(bufferPoolGB / 2);
+    if (calculations.innodb_buffer_pool_instances < expectedInstances * 0.5 && bufferPoolGB >= 16) {
+      recommendations.push(`WARNING: Your buffer pool has ${calculations.innodb_buffer_pool_instances} instances for ${bufferPoolGB.toFixed(1)}GB. Research recommends 1 instance per 1-2GB of buffer pool (${expectedInstances} instances) to reduce contention on larger servers.`);
+    }
+
+    // Large server specific recommendations
+    if (totalMemory >= 64) {
+      const bufferPoolRatio = calculations.innodb_buffer_pool_size / convertGBToBytes(availableMemory);
+      if (bufferPoolRatio < 0.75) {
+        recommendations.push("NOTE: For dedicated servers with 64GB+ RAM, research shows 75-88% buffer pool allocation is optimal. The old '70% rule' wastes memory on large servers.");
+      }
+    }
+
     if (scores.memoryAllocation < 15) {
       const memoryRatio = availableMemory / totalMemory;
       if (memoryRatio < 0.6) {
-        recommendations.push("Consider allocating more memory to MySQL by reducing reserved memory or memory for other tasks. For dedicated database servers, 70-80% of total memory should be available for MySQL.");
+        recommendations.push("Consider allocating more memory to MySQL by reducing reserved memory or memory for other tasks. For dedicated database servers with 64GB+, aim for 75-85% of total memory available for MySQL.");
       } else {
         recommendations.push("Your memory allocation is reasonable, but could be optimized further for better performance.");
       }
@@ -500,9 +569,12 @@ export class MySQLCalculator {
     if (scores.bufferPoolSize < 15) {
       const bufferPoolRatio = calculations.innodb_buffer_pool_size / convertGBToBytes(availableMemory);
       if (bufferPoolRatio < 0.6) {
-        recommendations.push("Increase innodb_buffer_pool_size to 70-80% of available memory for dedicated database servers, or 60-70% for shared servers. This is the most critical MySQL performance setting.");
-      } else if (bufferPoolRatio > 0.85) {
-        recommendations.push("Your innodb_buffer_pool_size may be too large. Consider reducing it to 75-80% of available memory to leave space for other MySQL operations and OS processes.");
+        const recommendation = totalMemory >= 64
+          ? "Increase innodb_buffer_pool_size to 75-85% of available memory for large dedicated servers (64GB+), or 60-70% for shared servers."
+          : "Increase innodb_buffer_pool_size to 70-80% of available memory for dedicated database servers, or 60-70% for shared servers.";
+        recommendations.push(recommendation + " This is the most critical MySQL performance setting.");
+      } else if (bufferPoolRatio > 0.88) {
+        recommendations.push("Your innodb_buffer_pool_size may be too large. Consider reducing it to 75-85% of available memory to leave space for other MySQL operations and OS processes.");
       }
     }
 
@@ -519,20 +591,26 @@ export class MySQLCalculator {
       const connectionsPerGB = calculations.max_connections / availableMemory;
       if (connectionsPerGB > 150) {
         recommendations.push("Your max_connections setting may be too high for available memory. Each connection uses memory; consider reducing connections or implementing connection pooling.");
-      } else {
-        recommendations.push("Consider adjusting max_connections based on your actual concurrent user requirements and available memory.");
+      } else if (calculations.max_connections < 100 && totalMemory >= 8) {
+        recommendations.push("Consider increasing max_connections based on your actual concurrent user requirements and available memory.");
       }
     }
 
     if (scores.ioSettings < 15) {
+      const storageType = inputs.storageType || 'ssd';
       if (calculations.innodb_io_capacity < availableMemory * 50) {
-        recommendations.push("Consider increasing innodb_io_capacity based on your storage capabilities. SSDs can typically handle 200+ IOPS per GB, NVMe drives even more.");
+        const storageAdvice = storageType === 'nvme'
+          ? "NVMe drives can handle 500+ IOPS per GB"
+          : storageType === 'ssd'
+          ? "SSDs can typically handle 200+ IOPS per GB"
+          : "Consider your storage capabilities";
+        recommendations.push(`Consider increasing innodb_io_capacity based on your storage capabilities. ${storageAdvice}.`);
       }
       if (calculations.innodb_read_io_threads < 4 || calculations.innodb_write_io_threads < 4) {
         recommendations.push("Increase innodb_read_io_threads and innodb_write_io_threads to at least 4 each for better I/O performance on modern hardware.");
       }
-      if (calculations.innodb_buffer_pool_instances === 1 && totalMemory >= 8) {
-        recommendations.push("Consider using multiple innodb_buffer_pool_instances (typically 1 instance per 1-2 GB of buffer pool) to reduce contention on larger servers.");
+      if (totalMemory >= 64 && (calculations.innodb_read_io_threads < 12 || calculations.innodb_write_io_threads < 12)) {
+        recommendations.push("Large servers (64GB+) benefit from 12-16 I/O threads to maximize parallel operations on modern storage.");
       }
     }
 

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -138,22 +138,66 @@ export function calculateBufferPoolInstances(bufferPoolSize, totalMemoryGB) {
   if (bufferPoolSize <= 1 * 1024 * 1024 * 1024) {
     return 1;
   }
-  
+
   const bufferPoolGB = convertBytesToGB(bufferPoolSize);
-  let instances = Math.min(Math.ceil(bufferPoolGB), 16);
-  
+
   // For smaller servers, don't add overhead of multiple instances
   if (totalMemoryGB < 4) {
-    instances = 1;
+    return 1;
   }
-  
+
+  // Research shows: 1 instance per 1-2GB of buffer pool is optimal
+  // For large buffer pools (64GB+), we need more instances to reduce contention
+  // Example: 96GB buffer pool should have 48-96 instances, not capped at 16
+  let instances;
+
+  if (bufferPoolGB >= 64) {
+    // Large pools: 1 instance per 1GB (more aggressive parallelization)
+    instances = Math.ceil(bufferPoolGB);
+  } else if (bufferPoolGB >= 32) {
+    // Medium-large pools: 1 instance per 1.5GB
+    instances = Math.ceil(bufferPoolGB / 1.5);
+  } else if (bufferPoolGB >= 16) {
+    // Medium pools: 1 instance per 2GB
+    instances = Math.ceil(bufferPoolGB / 2);
+  } else {
+    // Smaller pools: use original logic (1 instance per GB, capped at 16)
+    instances = Math.min(Math.ceil(bufferPoolGB), 16);
+  }
+
   return instances;
 }
 
 export function calculateIOThreads(totalMemoryGB) {
+  // Scale I/O threads based on server size
+  // Large servers benefit from more I/O threads to handle parallel operations
+  let readThreads, writeThreads;
+
+  if (totalMemoryGB >= 128) {
+    // Very large servers: 16 threads for maximum parallelism
+    readThreads = 16;
+    writeThreads = 16;
+  } else if (totalMemoryGB >= 64) {
+    // Large servers: 12 threads
+    readThreads = 12;
+    writeThreads = 12;
+  } else if (totalMemoryGB >= 32) {
+    // Medium-large servers: 8 threads
+    readThreads = 8;
+    writeThreads = 8;
+  } else if (totalMemoryGB >= 16) {
+    // Medium servers: 8 threads
+    readThreads = 8;
+    writeThreads = 8;
+  } else {
+    // Smaller servers: 4 threads
+    readThreads = 4;
+    writeThreads = 4;
+  }
+
   return {
-    read: totalMemoryGB > 16 ? 8 : 4,
-    write: totalMemoryGB > 16 ? 8 : 4
+    read: readThreads,
+    write: writeThreads
   };
 }
 


### PR DESCRIPTION
Based on research findings, implement significant optimizations for large server configurations:

1. Buffer Pool Size (64GB+ servers):
   - Increase from flat 70-75% to 80-85% for large dedicated servers
   - 128GB+ servers: 85% allocation (was 75%)
   - 64-128GB servers: 80% allocation (was 75%)
   - Research shows 75-88% is optimal; old 70% rule wastes memory on large servers

2. Max Connections Caps:
   - Add realistic caps based on research (typical workloads: 100-500 connections)
   - 128GB+: cap at 2000 connections
   - 64GB+: cap at 1500 connections
   - 32GB+: cap at 1000 connections
   - 16GB+: cap at 500 connections
   - Prevents unrealistic values like 15,000+ connections on very large servers
   - Each connection uses ~196KB + per-query buffers

3. Buffer Pool Instances:
   - Remove hardcoded cap of 16 instances
   - Implement proper scaling: 1 instance per 1-2GB of buffer pool
   - 64GB+ pools: 1 instance per 1GB (more aggressive parallelization)
   - 32-64GB pools: 1 instance per 1.5GB
   - 16-32GB pools: 1 instance per 2GB
   - Example: 96GB buffer pool now gets 96 instances instead of 16

4. I/O Capacity for NVMe:
   - More aggressive scaling for large NVMe systems
   - 128GB+ NVMe: 2.5x boost (was 1.3x)
   - 64-128GB NVMe: 2.0x boost
   - 32-64GB NVMe: 1.5x boost
   - Modern NVMe drives can handle much higher IOPS

5. I/O Threads Scaling:
   - 128GB+ servers: 16 I/O threads (was 8)
   - 64GB+ servers: 12 I/O threads (was 8)
   - Better parallelism for large servers

6. Enhanced Warnings:
   - Warn about connection counts >1500 (uncommonly high)
   - Alert about buffer pool instance ratios for optimal performance
   - Recommend 75-88% buffer pool for 64GB+ servers
   - Storage-specific I/O capacity recommendations

These changes ensure large servers are properly configured instead of being limited by settings designed for smaller systems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)