### PR TITLE
Fix loading state bug in calculation validation

### DIFF
--- a/assets/js/ui.js
+++ b/assets/js/ui.js
@@ -474,15 +474,15 @@ export class UIManager {
    */
   async performCalculation() {
     try {
-      this.setLoadingState('calculation', true);
-
       const inputs = this.collectInputs();
 
-      // Validate inputs are numbers
+      // Validate inputs are numbers before setting loading state
       if (isNaN(inputs.totalMemory) || isNaN(inputs.reservedMemory) || isNaN(inputs.otherTasksMemory)) {
         this.showError('Invalid memory values. Please enter valid numbers.');
         return;
       }
+
+      this.setLoadingState('calculation', true);
 
       const templateSettings = templateManager.getCurrentTemplate();
 
@@ -491,6 +491,7 @@ export class UIManager {
 
       if (!results || !results.calculations) {
         this.showError('Calculation failed to produce valid results.');
+        this.setLoadingState('calculation', false);
         return;
       }
 


### PR DESCRIPTION
Resolved issue where early returns in performCalculation() could leave the UI stuck in a loading state indefinitely. Changes:

- Move input validation before setLoadingState('calculation', true) to prevent entering loading state with invalid inputs
- Explicitly reset loading state before early return when results are invalid
- Keep finally block as safety net for error scenarios

This ensures the loading state is always properly reset, preventing UI freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)